### PR TITLE
fix(dominants): Reset All Dominant button now clears duplicate cards

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -606,6 +606,11 @@ export default function Home() {
   const resetAllDominants = () => {
     if (window.confirm('Are you sure you want to reset all dominant card assignments and tiers?')) {
       setDominantCardStates({});
+      
+      // Also clear all duplicate cards from localStorage
+      allDominants.forEach(dominant => {
+        localStorage.removeItem(`dominant-copies-${dominant.name}`);
+      });
     }
   };
 


### PR DESCRIPTION
- Modified resetAllDominants function to also remove duplicate card data from localStorage
- Previously only reset main dominant card states but left duplicates intact
- Now properly clears all dominant-copies-* localStorage entries for complete reset