### PR TITLE
fix(dominants): Reset All Dominant button now properly clears duplica…

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -87,6 +87,7 @@ export default function Home() {
   // Dominant Card States
   const [dominantCardStates, setDominantCardStates] = useState<{ [cardName: string]: DominantCardState }>({});
   const [dominantSearchTerm, setDominantSearchTerm] = useState('');
+  const [dominantResetTrigger, setDominantResetTrigger] = useState(0);
 
   // Trinket State
   const [trinketState, setTrinketState] = useState<{
@@ -611,6 +612,9 @@ export default function Home() {
       allDominants.forEach(dominant => {
         localStorage.removeItem(`dominant-copies-${dominant.name}`);
       });
+      
+      // Force DominantCard components to refresh by updating trigger
+      setDominantResetTrigger(prev => prev + 1);
     }
   };
 
@@ -786,6 +790,7 @@ export default function Home() {
                         assignedTo={cardState.assignedTo}
                         selectedTier={cardState.selectedTier}
                         searchTerm={dominantSearchTerm}
+                        resetTrigger={dominantResetTrigger}
                         onChange={(change) => handleDominantCardChange(dominant.name, change)}
                       />
                   )

--- a/src/components/DominantCard.tsx
+++ b/src/components/DominantCard.tsx
@@ -14,6 +14,7 @@ interface DominantCardProps {
   selectedTier: string | null;
   onChange: (change: { assignedTo?: string; selectedTier?: string | null }) => void;
   searchTerm?: string; // Optional search term for highlighting matches
+  resetTrigger?: number; // Trigger to force refresh of duplicate cards
 }
 
 interface CardCopy {
@@ -28,7 +29,8 @@ const DominantCard: React.FC<DominantCardProps> = ({
   assignedTo,
   selectedTier,
   onChange,
-  searchTerm = ''
+  searchTerm = '',
+  resetTrigger = 0
 }) => {
   const [cardCopies, setCardCopies] = useState<CardCopy[]>([]);
   const [showCopies, setShowCopies] = useState(false);
@@ -64,6 +66,14 @@ const DominantCard: React.FC<DominantCardProps> = ({
   useEffect(() => {
     localStorage.setItem(`dominant-copies-${dominant.name}`, JSON.stringify(cardCopies));
   }, [cardCopies, dominant.name]);
+
+  // Handle reset trigger - clear copies when parent triggers reset
+  useEffect(() => {
+    if (resetTrigger > 0) {
+      setCardCopies([]);
+      setShowCopies(false);
+    }
+  }, [resetTrigger]);
 
   const rollTier = () => {
     const tierKeys = Object.keys(dominant.tiers);


### PR DESCRIPTION
…te cards with UI refresh

- Enhanced resetAllDominants function to clear duplicate card localStorage entries
- Added dominantResetTrigger state mechanism for real-time UI updates
- Modified DominantCard component to accept resetTrigger prop and clear copies on trigger
- Duplicate cards now immediately disappear from UI without page refresh
- Complete reset functionality restored for both main cards and duplicates

Resolves issue where duplicate cards remained visible after reset until page refresh.